### PR TITLE
Adding Support for VarTRAM

### DIFF
--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -156,7 +156,7 @@ void CacheManager<Data>::addCache(MultiData<Data> multidata) {
 #if DEBUG
   CkPrintf("adding cache for node %d\n", multidata.nodes[0].key);
 #endif
-  Node<Data>* top_node = addCacheHelper(multidata.particles, multidata.n_particles, multidata.nodes, multidata.n_nodes);
+  Node<Data>* top_node = addCacheHelper(multidata.particles.data(), multidata.n_particles, multidata.nodes.data(), multidata.n_nodes);
   process(top_node->key);
 }
 

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -101,6 +101,11 @@ public:
     std::cout << "Universal bounding box: " << universe << " with volume "
       << universe.box.volume() << std::endl;
 
+    if (universe.n_particles <= max_particles_per_tp) {
+      CkPrintf("WARNING: Consider using -p to lower max_particles_per_tp, only %d particles.\n",
+        universe.n_particles);
+    }
+
     // Assign keys and sort particles locally
     start_time = CkWallTimer();
     readers.assignKeys(universe, CkCallbackResumeThread());

--- a/src/MultiData.h
+++ b/src/MultiData.h
@@ -6,15 +6,15 @@
 #include "common.h"
 #include "paratreet.decl.h"
 
+#include <vector>
+#include <iterator>
+
 template <typename Data>
 struct MultiData {
-  static constexpr size_t MAX_BRANCH_FACTOR = 8;
-  static constexpr size_t MAX_NUM_PARTICLES = MAX_BRANCH_FACTOR * MAX_BRANCH_FACTOR * MAX_PARTICLES_PER_LEAF;
-  static constexpr size_t MAX_NUM_NODES     = 1 + MAX_BRANCH_FACTOR + MAX_BRANCH_FACTOR * MAX_BRANCH_FACTOR;
   int n_particles;
   int n_nodes;
-  Particle particles [MAX_NUM_PARTICLES];
-  std::pair<Key, SpatialNode<Data>> nodes [MAX_NUM_NODES];
+  std::vector<Particle> particles;
+  std::vector<std::pair<Key, SpatialNode<Data>>> nodes;
 
   MultiData();
   MultiData(Particle*, int, Node<Data>**, int);
@@ -32,8 +32,8 @@ template <typename Data>
 inline MultiData<Data>::MultiData(Particle* particlesi, int n_particlesi, Node<Data>** nodesi, int n_nodesi) {
   n_particles   = n_particlesi;
   n_nodes       = n_nodesi;
-  std::copy(particlesi, particlesi + n_particles, particles);
-  std::transform(nodesi, nodesi + n_nodes, nodes, [] (Node<Data>* node) {
+  std::copy(particlesi, particlesi + n_particles, std::back_inserter(particles));
+  std::transform(nodesi, nodesi + n_nodes, std::back_inserter(nodes), [] (Node<Data>* node) {
     SpatialNode<Data> copy = *node;
     return std::make_pair(node->key, copy);
   });
@@ -43,8 +43,8 @@ template <typename Data>
 void MultiData<Data>::pup(PUP::er& p) {
   p | n_particles;
   p | n_nodes;
-  PUParray(p, particles, MAX_NUM_PARTICLES); // TODO varTram
-  PUParray(p, nodes,     MAX_NUM_NODES);
+  p | particles;
+  p | nodes;
 }
 
 


### PR DESCRIPTION
Makes `MultiData` a variable-sized object, and prints a warning when `max_particles_per_tp` is too small. The following "small" test now runs correctly on this branch:
`./charmrun ./paratreet -f ../inputgen/1k.tipsy -p 100 +p3 ++ppn 3 +pemap 1-3 +commap 0 ++local`