### PR TITLE
Sort particles by order before writing

### DIFF
--- a/src/Driver.h
+++ b/src/Driver.h
@@ -24,6 +24,7 @@
 #include "Resumer.h"
 #include "Modularization.h"
 #include "Node.h"
+#include "Writer.h"
 
 extern CProxy_Reader readers;
 extern CProxy_TreeSpec treespec;
@@ -197,7 +198,8 @@ public:
       // TODO: Initial force interactions similar to ChaNGa
       if (iter == 0 && verify) {
         std::string output_file = input_file + ".acc";
-        treepieces[0].output(output_file, CkCallbackResumeThread());
+        CProxy_Writer w = CProxy_Writer::ckNew(n_treepieces, output_file);
+        treepieces[0].output(w, CkCallbackResumeThread());
         CkPrintf("Outputting particle accelerations for verification...\n");
       }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,7 +20,7 @@ $(BINARY).decl.h: $(BINARY).ci
 
 common.h: $(STRUCTURE_PATH)/Vector3D.h $(STRUCTURE_PATH)/SFC.h Utility.h
 
-Main.o: Main.C $(BINARY).decl.h common.h Reader.h TreePiece.h TreeSpec.h BoundingBox.h BufferedVec.h TreeCanopy.h CacheManager.h Node.h Resumer.h Traverser.h Driver.h GravityVisitor.h DensityVisitor.h PressureVisitor.h CountVisitor.h
+Main.o: Main.C $(BINARY).decl.h common.h Reader.h TreePiece.h TreeSpec.h BoundingBox.h BufferedVec.h TreeCanopy.h CacheManager.h Node.h Resumer.h Traverser.h Driver.h GravityVisitor.h DensityVisitor.h PressureVisitor.h CountVisitor.h Writer.h
 	$(CHARMC) -c $<
 
 CacheManager.h: $(BINARY).decl.h

--- a/src/Writer.h
+++ b/src/Writer.h
@@ -21,15 +21,18 @@ Writer::Writer(int n_treepieces, std::string of)
 
 void Writer::receive(std::vector<Particle> ps, CkCallback cb)
 {
-  --num_treepieces;
+  // Accumulate received particles
   particles.insert(particles.end(), ps.begin(), ps.end());
-  if (num_treepieces != 0) return;
 
+  if (--num_treepieces > 0) return;
+
+  // Received from all treepieces, sort the particles
   std::sort(particles.begin(), particles.end(),
             [](const Particle& left, const Particle& right) {
               return left.order < right.order;
             });
 
+  // Write particle accelerations to output file
   FILE *fp = CmiFopen(output_file.c_str(), "w");
   CkAssert(fp);
   fprintf(fp, "%lu\n", particles.size());

--- a/src/Writer.h
+++ b/src/Writer.h
@@ -1,0 +1,53 @@
+
+#ifndef _WRITER_H_
+#define _WRITER_H_
+
+#include "paratreet.decl.h"
+#include <vector>
+
+struct Writer : public CBase_Writer {
+  Writer(int n_treepieces, std::string of);
+  void receive(std::vector<Particle> particles, CkCallback cb);
+
+private:
+  std::vector<Particle> particles;
+  int num_treepieces;
+  std::string output_file;
+};
+
+Writer::Writer(int n_treepieces, std::string of)
+  : num_treepieces(n_treepieces), output_file(of)
+{}
+
+void Writer::receive(std::vector<Particle> ps, CkCallback cb)
+{
+  --num_treepieces;
+  particles.insert(particles.end(), ps.begin(), ps.end());
+  if (num_treepieces != 0) return;
+
+  std::sort(particles.begin(), particles.end(),
+            [](const Particle& left, const Particle& right) {
+              return left.order < right.order;
+            });
+
+  FILE *fp = CmiFopen(output_file.c_str(), "w");
+  CkAssert(fp);
+  fprintf(fp, "%lu\n", particles.size());
+
+  for (int dim = 0; dim < 3; ++dim) {
+    for (const auto& particle : particles) {
+      Real outval;
+      if (dim == 0) outval = particle.acceleration.x;
+      else if (dim == 1) outval = particle.acceleration.y;
+      else if (dim == 2) outval = particle.acceleration.z;
+      fprintf(fp, "%.14g\n", outval);
+    }
+  }
+
+  int result = CmiFclose(fp);
+  CkAssert(result == 0);
+
+  cb.send();
+}
+
+#endif /* _WRITER_H_ */

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -75,6 +75,11 @@ mainmodule paratreet {
   };
   group Resumer<CentroidData>;
 
+  chare Writer {
+    entry Writer(int n_treepieces, std::string of);
+    entry void receive(std::vector<Particle> particles, CkCallback cb);
+  }
+
   template <typename Data>
   array [1d] TreePiece {
     entry TreePiece(const CkCallback&, int, int, TCHolder<Data>, CProxy_Resumer<Data>, CProxy_CacheManager<Data>, DPHolder<Data>);
@@ -93,7 +98,7 @@ mainmodule paratreet {
     entry void flush(CProxy_Reader);
 
     entry void checkParticlesChanged(const CkCallback&);
-    entry void output(std::string, const CkCallback&);
+    entry void output(CProxy_Writer w, CkCallback cb);
   };
   array [1d] TreePiece<CentroidData>;
 


### PR DESCRIPTION
This addresses issue #16 by gathering particles in a single Writer chare and sorting particles by order before writing output.