### PR TITLE
Change Writer to a chare group

### DIFF
--- a/src/Driver.h
+++ b/src/Driver.h
@@ -198,7 +198,7 @@ public:
       // TODO: Initial force interactions similar to ChaNGa
       if (iter == 0 && verify) {
         std::string output_file = input_file + ".acc";
-        CProxy_Writer w = CProxy_Writer::ckNew(n_treepieces, output_file);
+        CProxy_Writer w = CProxy_Writer::ckNew(output_file, universe.n_particles);
         treepieces[0].output(w, CkCallbackResumeThread());
         CkPrintf("Outputting particle accelerations for verification...\n");
       }

--- a/src/TreePiece.h
+++ b/src/TreePiece.h
@@ -579,7 +579,31 @@ void TreePiece<Data>::output(CProxy_Writer w, CkCallback cb) {
                      leaf->particles(), leaf->particles() + leaf->n_particles);
   }
 
-  w.receive(particles, cb);
+  std::sort(particles.begin(), particles.end(),
+            [](const Particle& left, const Particle& right) {
+              return left.order < right.order;
+            });
+
+  int particles_per_writer = n_total_particles / CkNumPes();
+  if (particles_per_writer * CkNumPes() != n_total_particles)
+    ++particles_per_writer;
+
+  int particle_idx = 0;
+  while (particle_idx < particles.size()) {
+    int writer_idx = particles[particle_idx].order / particles_per_writer;
+    int first_particle = writer_idx * particles_per_writer;
+    std::vector<Particle> writer_particles;
+
+    while (
+      particles[particle_idx].order < first_particle + particles_per_writer
+      && particle_idx < particles.size()
+      ) {
+      writer_particles.push_back(particles[particle_idx]);
+      ++particle_idx;
+    }
+
+    w[writer_idx].receive(writer_particles, cb);
+  }
 
   if (this->thisIndex != n_treepieces - 1) {
     this->thisProxy[this->thisIndex + 1].output(w, cb);

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -75,9 +75,10 @@ mainmodule paratreet {
   };
   group Resumer<CentroidData>;
 
-  chare Writer {
-    entry Writer(int n_treepieces, std::string of);
+  group Writer {
+    entry Writer(std::string of, int n_particles);
     entry void receive(std::vector<Particle> particles, CkCallback cb);
+    entry void write(CkCallback cb);
   }
 
   template <typename Data>


### PR DESCRIPTION
This PR changes the Writer chare to a chare group to address #18 . 
Each TreePiece sorts particles locally and sends particles within specific order ranges to the corresponding writers, as Tom described [here](https://github.com/paratreet/paratreet/pull/17#issuecomment-652192661).