### PR TITLE
Create libparatreet.a for user applications

### DIFF
--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -4,21 +4,21 @@ PARATREET_PATH = $(BASE_PATH)/src
 STRUCTURE_PATH = $(BASE_PATH)/utility/structures
 OPTS = -g -I$(STRUCTURE_PATH) -I$(PARATREET_PATH) -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
 CHARMC = $(CHARM_HOME)/bin/charmc $(OPTS)
-LD_LIBS = -L$(STRUCTURE_PATH) -lTipsy $(PARATREET_PATH)/*.o
+LD_LIBS = -L$(PARATREET_PATH) -lparatreet
 
 BINARY = Main
-OBJS = Main.o 
+OBJS = Main.o
 
 all: $(BINARY)
 
 $(BINARY).decl.h: $(BINARY).ci
 	$(CHARMC) $<
 
-$(BINARY): $(BINARY).decl.h $(OBJS) 
-	$(CHARMC) -language charm++ -o $(BINARY) $(OBJS) $(LD_LIBS) 
+$(BINARY): $(BINARY).decl.h $(OBJS)
+	$(CHARMC) -language charm++ -o $(BINARY) $(OBJS) $(LD_LIBS)
 
 Main.o: Main.C
-	$(CHARMC) -c $< 
+	$(CHARMC) -c $<
 
 test: all
 	./charmrun ./$(BINARY) -f $(BASE_PATH)/inputgen/100k.tipsy +p3 ++ppn 3 +pemap 1-3 +commap 0 ++local

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -142,7 +142,11 @@ public:
 
       // Start tree build in TreePieces
       start_time = CkWallTimer();
-      treepieces.buildTree();
+      if (config.tree_type == OCT_TREE) {
+        treepieces.buildTree();
+      } else {
+        CkAbort("Only octree is currently supported");
+      }
       CkWaitQD();
       CkPrintf("Tree build: %.3lf ms\n", (CkWallTimer() - start_time) * 1000);
 

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -142,11 +142,7 @@ public:
 
       // Start tree build in TreePieces
       start_time = CkWallTimer();
-      if (config.tree_type == OCT_TREE) {
-        treepieces.buildTree();
-      } else {
-        CkAbort("Only octree is currently supported");
-      }
+      treepieces.buildTree();
       CkWaitQD();
       CkPrintf("Tree build: %.3lf ms\n", (CkWallTimer() - start_time) * 1000);
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,31 +2,27 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 STRUCTURE_PATH = ../utility/structures
 OPTS = -g -I$(STRUCTURE_PATH) -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
 CHARMC = $(CHARM_HOME)/bin/charmc $(OPTS)
-LD_LIBS = -L$(STRUCTURE_PATH) -lTipsy
 
-BINARY = paratreet
 OBJS = Paratreet.o Reader.o Writer.o Particle.o BoundingBox.o Decomposition.o Modularization.o TreeSpec.o
+TIPSY_OBJS = NChilReader.o SS.o TipsyFile.o TipsyReader.o hilbert.o
 
-all: $(BINARY).o
+all: lib
 
-$(BINARY).o: $(OBJS)
-	$(CHARMC) -language charm++ -c $(OBJS) $(LD_LIBS)
+lib: $(OBJS)
+	ar x $(STRUCTURE_PATH)/libTipsy.a
+	ar cr libparatreet.a $(OBJS) $(TIPSY_OBJS)
+	rm -f $(TIPSY_OBJS)
+	ranlib libparatreet.a
 
-proj: $(OBJS)
-	$(CHARMC) -language charm++ -tracemode projections -o $(BINARY) $(OBJS) $(LD_LIBS)
-
-$(BINARY).decl.h: $(BINARY).ci
+paratreet.decl.h: paratreet.ci
 	$(CHARMC) $<
 
 common.h: $(STRUCTURE_PATH)/Vector3D.h $(STRUCTURE_PATH)/SFC.h Utility.h
 
-CacheManager.h: $(BINARY).decl.h
+CacheManager.h: paratreet.decl.h
 
-%.o: %.C %.h $(BINARY).decl.h
+%.o: %.C %.h paratreet.decl.h
 	$(CHARMC) -c $<
 
-test: all
-	./charmrun ./paratreet -f ../inputgen/100k.tipsy +p3 ++ppn 3 +pemap 1-3 +commap 0 ++local
-
 clean:
-	rm -f *.decl.h *.def.h conv-host *.o $(BINARY) charmrun
+	rm -f *.decl.h *.def.h conv-host *.o libparatreet.a charmrun


### PR DESCRIPTION
This PR updates `Makefile` to create `libparatreet.a`, which can be linked from user applications.
`libparatreet.a` also contains object files from the Tipsy library, which are obtained with `ar x $(STRUCTURE_PATH)/libTipsy.a`.
User applications only need to link ParaTreeT as a library with `-lparatreet`, without linking the Tipsy library.
The `simple` example has been updated to reflect this change.