### PR TITLE
Reworked per-iteration functions to be more accessible

### DIFF
--- a/examples/simple/Main.C
+++ b/examples/simple/Main.C
@@ -1,6 +1,20 @@
 #include "Main.decl.h"
 #include "Paratreet.h"
 
+/*readonly*/ bool verify;
+
+namespace paratreet {
+  void traversalFn(BoundingBox& universe, CProxy_TreePiece<CentroidData>& tp, int iter) {
+    tp.template startDown<GravityVisitor>();
+  }
+
+  void postInteractionsFn(BoundingBox& universe, CProxy_TreePiece<CentroidData>& tp, int iter) {
+    if (iter == 0 && verify) {
+      paratreet::outputParticles(universe, tp);
+    }
+  }
+}
+
 class Main : public CBase_Main {
   int n_treepieces; // Cannot be a readonly because of OCT decomposition
   int cur_iteration;
@@ -29,18 +43,6 @@ class Main : public CBase_Main {
     conf.cache_share_depth= 3;
     conf.flush_period = 1;
     conf.timestep_size = 0.1;
-
-    conf.traversalFn = [] (CProxy_TreePiece<CentroidData>& tp, int iter) {
-      tp.template startDown<GravityVisitor>();
-    };
-
-    const bool* verifyPtr = &this->verify;
-    conf.postInteractionsFn =
-      [verifyPtr] (BoundingBox& universe, CProxy_TreePiece<CentroidData>& tp, int iter) {
-        if (iter == 0 && *verifyPtr) {
-          paratreet::outputParticles(universe, tp);
-        }
-      };
 
     verify = false;
 

--- a/examples/simple/Main.ci
+++ b/examples/simple/Main.ci
@@ -1,5 +1,6 @@
 mainmodule Main {
     extern module paratreet;
+    readonly bool verify;
 
     mainchare Main {
         initnode void initialize();

--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -26,7 +26,8 @@ public:
   Data nodewide_data;
 
   CacheManager() {
-    initialize();
+    CkCallback cb(CkIndex_CacheManager<Data>::initialize(), this->thisProxy[this->thisIndex]);
+    treespec.check(cb);
   }
 
   void initialize() {

--- a/src/Configuration.h
+++ b/src/Configuration.h
@@ -11,9 +11,6 @@ template<typename T>
 class CProxy_TreePiece;
 
 namespace paratreet {
-    using TraversalFn = std::function<void(CProxy_TreePiece<CentroidData>&,int)>;
-    using PostInteractionsFn = std::function<void(BoundingBox&,CProxy_TreePiece<CentroidData>&,int)>;
-
     struct Configuration {
         double decomp_tolerance;
         int max_particles_per_tp; // For OCT decomposition
@@ -26,8 +23,6 @@ namespace paratreet {
         int flush_period;
         Real timestep_size;
         std::string input_file;
-        TraversalFn traversalFn;
-        PostInteractionsFn postInteractionsFn;
 #ifdef __CHARMC__
 #include "pup.h"
         void pup(PUP::er &p) {

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -33,6 +33,11 @@ extern CProxy_CacheManager<CentroidData> centroid_cache;
 extern CProxy_Resumer<CentroidData> centroid_resumer;
 extern CProxy_CountManager count_manager;
 
+namespace paratreet {
+  extern void traversalFn(BoundingBox&,CProxy_TreePiece<CentroidData>&,int);
+  extern void postInteractionsFn(BoundingBox&,CProxy_TreePiece<CentroidData>&,int);
+}
+
 template <typename Data>
 class Driver : public CBase_Driver<Data> {
 private:
@@ -155,7 +160,7 @@ public:
       start_time = CkWallTimer();
       //treepieces.template startUpAndDown<DensityVisitor>();
       //treepieces.template startDown<GravityVisitor>();
-      treespec.ckLocalBranch()->getConfiguration().traversalFn(treepieces, iter);
+      paratreet::traversalFn(universe, treepieces, iter);
       CkWaitQD();
 #if DELAYLOCAL
       //treepieces.processLocal(CkCallbackResumeThread());
@@ -178,7 +183,7 @@ public:
       // Call user's post-interaction function, which may for example:
       // Output particle accelerations for verification
       // TODO: Initial force interactions similar to ChaNGa
-      treespec.ckLocalBranch()->getConfiguration().postInteractionsFn(universe, treepieces, iter);
+      paratreet::postInteractionsFn(universe, treepieces, iter);
 
       // Destroy treepieces and perform decomposition from scratch
       if (complete_rebuild) {

--- a/src/Paratreet.C
+++ b/src/Paratreet.C
@@ -33,9 +33,6 @@ namespace paratreet {
         readers = CProxy_Reader::ckNew();
         treespec = CProxy_TreeSpec::ckNew(conf);
 
-        // Set the local branch's configuration (function pointers remain intact)
-        treespec.ckLocalBranch()->setConfiguration(conf);
-
         // Create centroid data related chares
         centroid_calculator = CProxy_TreeCanopy<CentroidData>::ckNew();
         centroid_cache = CProxy_CacheManager<CentroidData>::ckNew();

--- a/src/Paratreet.h
+++ b/src/Paratreet.h
@@ -27,6 +27,9 @@
 /* readonly */ extern CProxy_Driver<CentroidData> centroid_driver;
 
 namespace paratreet {
+    extern void traversalFn(BoundingBox&,CProxy_TreePiece<CentroidData>&,int);
+    extern void postInteractionsFn(BoundingBox&,CProxy_TreePiece<CentroidData>&,int);
+
     void initialize(const Configuration&, CkCallback);
     void run(CkCallback);
     void updateConfiguration(const Configuration&, CkCallback);

--- a/src/TreeSpec.C
+++ b/src/TreeSpec.C
@@ -1,5 +1,10 @@
 #include "TreeSpec.h"
 
+void TreeSpec::check(const CkCallback &cb) {
+  CkAssert(this->getTree() && this->getDecomposition());
+  cb.send();
+}
+
 void TreeSpec::receiveDecomposition(CkMarshallMsg* msg) {
   char *buffer = msg->msgBuf;
   PUP::fromMem pupper(buffer);

--- a/src/TreeSpec.h
+++ b/src/TreeSpec.h
@@ -10,8 +10,9 @@ public:
     TreeSpec(const paratreet::Configuration& config_)
     : config(config_),
       decomp(nullptr),
-      tree(nullptr) { getTree(); }
+      tree(nullptr) { }
 
+    void check(const CkCallback &cb);
     void receiveDecomposition(CkMarshallMsg*);
     Decomposition* getDecomposition();
 
@@ -27,8 +28,8 @@ public:
     void setConfiguration(const paratreet::Configuration& config_) { config = config_; }
 
     template <typename Data>
-    Node<Data>* makeNode(Key key, int depth, int n_particles, Particle* particles, int owner_tp_start, int owner_tp_end, bool is_leaf, Node<Data>* parent, int tp_index) const {
-      switch (tree->getBranchFactor()) {
+    Node<Data>* makeNode(Key key, int depth, int n_particles, Particle* particles, int owner_tp_start, int owner_tp_end, bool is_leaf, Node<Data>* parent, int tp_index) {
+      switch (getTree()->getBranchFactor()) {
       case 2:
         return new FullNode<Data, 2> (key, depth, n_particles, particles, owner_tp_start, owner_tp_end, is_leaf, parent, tp_index);
       case 8:
@@ -45,7 +46,7 @@ public:
         particles = new Particle [spatial_node.n_particles];
         std::copy(particlesToCopy, particlesToCopy + spatial_node.n_particles, particles);
       }
-      switch (tree->getBranchFactor()) {
+      switch (getTree()->getBranchFactor()) {
       case 2:
         return new FullNode<Data, 2> (key, type, spatial_node.is_leaf, spatial_node, particles, parent);
       case 8:

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -40,6 +40,7 @@ module paratreet {
   nodegroup CacheManager {
 #endif
     entry CacheManager();
+    entry void initialize();
     entry void requestNodes(std::pair<Key, int>);
     entry void recvStarterPack(std::pair<Key, SpatialNode<Data>> pack [n], int n, CkCallback);
     entry void addCache(MultiData<Data>);
@@ -145,6 +146,7 @@ module paratreet {
 
   group TreeSpec {
     entry TreeSpec(const paratreet::Configuration&);
+    entry void check(const CkCallback&);
     entry void receiveDecomposition(CkMarshallMsg*);
     entry [local] Decomposition* getDecomposition();
     entry void receiveConfiguration(const paratreet::Configuration&,CkCallback);


### PR DESCRIPTION
Previously, the per-iteration functions were not accessible if the `Driver` chare migrated to be on a different PE besides the same one as the mainchare. This PR addresses this issue by moving the per-iteration functions to globally accessible, externally linked functions.