### PR TITLE
Add multi-process test to SMP version of GitHub CI

### DIFF
--- a/.github/workflows/smp.yml
+++ b/.github/workflows/smp.yml
@@ -47,4 +47,5 @@ jobs:
         make -j4
         cd ../examples/simple
         make
-        ./charmrun +p3 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 3 +setcpuaffinity 0 ++local
+        ./charmrun +p4 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 4 +setcpuaffinity ++local
+        ./charmrun +p4 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 2 +setcpuaffinity ++local


### PR DESCRIPTION
Adds a 2-process test for GitHub CI SMP.
To be merged after #46.