### PR TITLE
Fix segfault due to uninitialized Tree and Decomposition

### DIFF
--- a/.github/workflows/non_smp.yml
+++ b/.github/workflows/non_smp.yml
@@ -47,4 +47,5 @@ jobs:
         make -j4 MAKE_OPTS="-DGROUP_CACHE"
         cd ../examples/simple
         make
+        ./charmrun +p1 ./Main -f ../../inputgen/1k.tipsy -p 100 ++local
         ./charmrun +p4 ./Main -f ../../inputgen/1k.tipsy -p 100 ++local

--- a/.github/workflows/smp.yml
+++ b/.github/workflows/smp.yml
@@ -47,5 +47,6 @@ jobs:
         make -j4
         cd ../examples/simple
         make
+        ./charmrun +p1 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 1 +setcpuaffinity ++local
         ./charmrun +p4 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 4 +setcpuaffinity ++local
         ./charmrun +p4 ./Main -f ../../inputgen/1k.tipsy -p 100 ++ppn 2 +setcpuaffinity ++local

--- a/src/TreeSpec.h
+++ b/src/TreeSpec.h
@@ -19,8 +19,8 @@ public:
     Tree* getTree();
 
     int doFindSplitters(BoundingBox &universe, CProxy_Reader &readers) {
-        int log_branch_factor = log2(tree->getBranchFactor());
-        return decomp->findSplitters(universe, readers, log_branch_factor);
+        int log_branch_factor = log2(getTree()->getBranchFactor());
+        return getDecomposition()->findSplitters(universe, readers, log_branch_factor);
     }
 
     void receiveConfiguration(const paratreet::Configuration&,CkCallback);


### PR DESCRIPTION
This PR fixes a segfault which occurs in a single PE run due to uninitialized `Tree` and `Decomposition` in `TreeSpec`.
Also adds single PE test cases to GitHub CI.