### PR TITLE
Correct CacheManager's Initialization Behavior

### DIFF
--- a/src/CacheManager.h
+++ b/src/CacheManager.h
@@ -25,9 +25,11 @@ public:
   CProxy_Resumer<Data> r_proxy;
   Data nodewide_data;
 
-  CacheManager() {
-    CkCallback cb(CkIndex_CacheManager<Data>::initialize(), this->thisProxy[this->thisIndex]);
-    treespec.check(cb);
+  CacheManager() { }
+
+  void initialize(const CkCallback& cb) {
+    this->initialize();
+    this->contribute(cb);
   }
 
   void initialize() {

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -56,6 +56,12 @@ public:
 
   // Performs initial decomposition
   void init(CkCallback cb) {
+    // Ensure all treespecs have been created
+    CkPrintf("* Validating tree specifications.\n");
+    treespec.check(CkCallbackResumeThread());
+    // Then, initialize the cache managers
+    CkPrintf("* Initializing cache managers.\n");
+    cache_manager.initialize(CkCallbackResumeThread());
     // Useful particle keys
     CkPrintf("* Initialization\n");
     decompose(0);

--- a/src/TreeSpec.C
+++ b/src/TreeSpec.C
@@ -2,7 +2,7 @@
 
 void TreeSpec::check(const CkCallback &cb) {
   CkAssert(this->getTree() && this->getDecomposition());
-  cb.send();
+  this->contribute(cb);
 }
 
 void TreeSpec::receiveDecomposition(CkMarshallMsg* msg) {

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -40,7 +40,7 @@ module paratreet {
   nodegroup CacheManager {
 #endif
     entry CacheManager();
-    entry void initialize();
+    entry void initialize(const CkCallback&);
     entry void requestNodes(std::pair<Key, int>);
     entry void recvStarterPack(std::pair<Key, SpatialNode<Data>> pack [n], int n, CkCallback);
     entry void addCache(MultiData<Data>);


### PR DESCRIPTION
@mojoe12 pointed out that `TreeSpec::check` was getting broadcasted `numNodes` times, and each `CacheManager`'s `initialize` entry method was getting called `numNodes / numPes` times. This patch moves the initialization logic to `Driver`, and ensures each entry method is now called only once (per element).