### PR TITLE
Add decomp array map

### DIFF
--- a/src/Decomposition.C
+++ b/src/Decomposition.C
@@ -78,16 +78,17 @@ int SfcDecomposition::findSplitters(BoundingBox &universe, CProxy_Reader &reader
 
   saved_n_total_particles = universe.n_particles;
   int threshold = saved_n_total_particles / min_n_splitters;
+  int n_splitters = min_n_splitters - 1;
   if (saved_n_total_particles % min_n_splitters > 0) threshold++;
-  for (int i = 0; i < min_n_splitters; ++i) {
+  else n_splitters++;
+  for (int i = 0; i < n_splitters; ++i) {
     Key from = keys[(int)(i * threshold)];
     Key to;
     int n_particles = (int)threshold;
-    if (i + 1 == min_n_splitters) {
+    if ((i + 1) * threshold >= saved_n_total_particles) {
       to = ~Key(0);
       n_particles = keys.size() - (int)(i * threshold);
     } else to = keys[(int)((i + 1) * threshold)];
-
     // Inverse bitwise-xor is used as a bitwise equality test, in conjunction with
     // `removeTrailingBits` forms a mask that zeroes off all bits after the first
     // differing bit between `from` and `to`
@@ -107,7 +108,6 @@ int SfcDecomposition::findSplitters(BoundingBox &universe, CProxy_Reader &reader
     CkAbort("SFC Decomposition failure -- see stdout");
   }
 
-  saved_n_total_particles = universe.n_particles;
   // Sort our splitters
   std::sort(splitters.begin(), splitters.end());
 

--- a/src/Decomposition.C
+++ b/src/Decomposition.C
@@ -76,9 +76,9 @@ int SfcDecomposition::findSplitters(BoundingBox &universe, CProxy_Reader &reader
 
   int decomp_particle_sum = 0;
 
-  int n_total_particles = keys.size();
-  int threshold = n_total_particles / min_n_splitters;
-  if (n_total_particles % min_n_splitters > 0) threshold++;
+  saved_n_total_particles = universe.n_particles;
+  int threshold = saved_n_total_particles / min_n_splitters;
+  if (saved_n_total_particles % min_n_splitters > 0) threshold++;
   for (int i = 0; i < min_n_splitters; ++i) {
     Key from = keys[(int)(i * threshold)];
     Key to;
@@ -248,7 +248,6 @@ int OctDecomposition::findSplitters(BoundingBox &universe, CProxy_Reader &reader
              decomp_particle_sum, universe.n_particles);
     CkAbort("Decomposition failure -- see stdout");
   }
-  saved_n_total_particles = universe.n_particles;
 
   // Sort our splitters
   std::sort(splitters.begin(), splitters.end());

--- a/src/Decomposition.C
+++ b/src/Decomposition.C
@@ -247,6 +247,7 @@ int OctDecomposition::findSplitters(BoundingBox &universe, CProxy_Reader &reader
 
   // Sort our splitters
   std::sort(splitters.begin(), splitters.end());
+  saved_n_total_particles = universe.n_particles;
 
   // Return the number of TreePieces
   return splitters.size();

--- a/src/Decomposition.h
+++ b/src/Decomposition.h
@@ -42,8 +42,6 @@ struct Decomposition: public PUP::able {
   virtual Key getTpKey(int idx) = 0;
 
   virtual void setArrayOpts(CkArrayOptions& opts) {
-    CProxy_DefaultArrayMap myMap = CProxy_DefaultArrayMap::ckNew();
-    opts.setMap(myMap);
   }
 
   std::vector<Key> getAllTpKeys(int n_partitions) {

--- a/src/Decomposition.h
+++ b/src/Decomposition.h
@@ -41,7 +41,10 @@ struct Decomposition: public PUP::able {
 
   virtual Key getTpKey(int idx) = 0;
 
-  virtual void setArrayOpts(CkArrayOptions& opts) {}
+  virtual void setArrayOpts(CkArrayOptions& opts) {
+    CProxy_DefaultArrayMap myMap = CProxy_DefaultArrayMap::ckNew();
+    opts.setMap(myMap);
+  }
 
   std::vector<Key> getAllTpKeys(int n_partitions) {
     std::vector<Key> tp_keys (n_partitions);

--- a/src/Driver.h
+++ b/src/Driver.h
@@ -87,6 +87,15 @@ public:
     universe = *((BoundingBox*)result->getData());
     delete result;
 
+    Vector3D<Real> bsize = universe.box.size();
+    Real max = (bsize.x > bsize.y) ? bsize.x : bsize.y;
+    max = (max > bsize.z) ? max : bsize.z;
+    Vector3D<Real> bcenter = universe.box.center();
+    // The magic number below is approximately 2^(-19)
+    const Real fEps = 1.0 + 1.91e-6;  // slop to ensure keys fall between 0 and 1.
+    bsize = Vector3D<Real>(fEps*0.5*max);
+    universe.box = OrientedBox<Real>(bcenter-bsize, bcenter+bsize);
+
     std::cout << "Universal bounding box: " << universe << " with volume "
       << universe.box.volume() << std::endl;
 

--- a/src/Partition.h
+++ b/src/Partition.h
@@ -249,6 +249,7 @@ void Partition<Data>::perturb(TPHolder<Data> tp_holder, Real timestep, bool if_f
 {
   std::vector<Particle> particles;
   copyParticles(particles);
+  r_local->countParticles(particles.size());
   for (auto && p : particles) {
     p.perturb(timestep, readers.ckLocalBranch()->universe.box);
   }

--- a/src/Resumer.h
+++ b/src/Resumer.h
@@ -20,10 +20,13 @@ private: // stats
   unsigned long long n_node_ints = 0ull;
   unsigned long long n_opens     = 0ull;
   unsigned long long n_closes    = 0ull;
+  unsigned long long n_particles = 0ull;
 
 public:
   void collectAndResetStats(CkCallback cb) {
+     CkPrintf("%llu particles on pe %d\n", n_particles, CkMyPe());
      unsigned long long intrn_counts [4] = {n_node_ints, n_part_ints, n_opens, n_closes};
+     CkPrintf("on PE %d: %llu node-particle interactions, %llu bucket-particle interactions %llu node opens, %llu node closes\n", CkMyPe(), intrn_counts[0], intrn_counts[1], intrn_counts[2], intrn_counts[3]);
      this->contribute(4 * sizeof(unsigned long long), &intrn_counts, CkReduction::sum_ulong_long, cb);
      reset();
   }
@@ -35,7 +38,7 @@ public:
     }
     CkAssert(waiting.empty()); // should have gotten rid of them
 #endif
-    n_part_ints = n_node_ints = n_opens = n_closes = 0ull;
+    n_part_ints = n_node_ints = n_opens = n_closes = n_particles = 0ull;
   }
 
   void countLeafInts(int n_ints) {
@@ -48,6 +51,10 @@ public:
 
   void countOpen(bool should_open) {
     should_open ? n_opens++ : n_closes++;
+  }
+
+  void countParticles(int n_parts) {
+    n_particles += n_parts;
   }
 
   void process(Key key) {

--- a/src/Traverser.h
+++ b/src/Traverser.h
@@ -24,7 +24,7 @@ template <typename Visitor, typename Node, typename StatCollector>
 inline void doLeaf(Node* source, Node* target, StatCollector* stats) {
   Visitor::leaf(*source, *target);
 #if COUNT_INTERACTIONS
-  stats->countLeafInts(target->n_particles);
+  stats->countLeafInts(source->n_particles * target->n_particles);
 #endif
 }
 

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -157,6 +157,10 @@ module paratreet {
     entry [local] void setConfiguration(const paratreet::Configuration&);
   }
 
+  group DecompArrayMap : CkArrayMap {
+    entry DecompArrayMap(CkPointer<Decomposition>, int, int);
+  };
+
   extern entry void Reader request<CentroidData>(CProxy_Subtree<CentroidData>, int, int);
   extern entry void Reader flush<CentroidData>(int, int, CProxy_Subtree<CentroidData>);
   extern entry void Reader assignPartitions<CentroidData>(int, int, CProxy_Partition<CentroidData>);


### PR DESCRIPTION
if you set COUNT_INTERACTIONS to 1, and run this:
`./Gravity -f $(BASE_PATH)/inputgen/100k.tipsy +p64 ++ppn 64 +pemap 1-64 +commap 0 -t bin -d sfc -n 512 -p 512`
you'll find a very strange bug in charm:
all the Partitions go onto the 0th PE. 
