### PR TITLE
Use Hypercomm library to aggregate messages

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "psortingV"]
-	path = psortingV
-	url = charmgit:users/vipulharsh/psortingV
 [submodule "utility"]
 	path = utility
 	url = https://github.com/N-BodyShop/utility.git
+[submodule "hypercomm-aggregation"]
+	path = hypercomm-aggregation
+	url = git@github.com:Wingpad/hypercomm-aggregation.git

--- a/examples/simple/Makefile
+++ b/examples/simple/Makefile
@@ -2,7 +2,8 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 BASE_PATH=$(shell realpath "$(shell pwd)/../..")
 PARATREET_PATH = $(BASE_PATH)/src
 STRUCTURE_PATH = $(BASE_PATH)/utility/structures
-OPTS = -g -I$(STRUCTURE_PATH) -I$(PARATREET_PATH) -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
+HYPERCOMM_PATH = $(BASE_PATH)/hypercomm-aggregation
+OPTS = -g -I$(STRUCTURE_PATH) -I$(PARATREET_PATH) -I$(HYPERCOMM_PATH)/include -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
 CHARMC = $(CHARM_HOME)/bin/charmc $(OPTS)
 LD_LIBS = -L$(PARATREET_PATH) -lparatreet
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,7 @@
 CHARM_HOME ?= $(HOME)/charm-paratreet
 STRUCTURE_PATH = ../utility/structures
-OPTS = -g -I$(STRUCTURE_PATH) -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
+HYPERCOMM_PATH = ../hypercomm-aggregation
+OPTS = -g -I$(STRUCTURE_PATH) -I$(HYPERCOMM_PATH)/include -DCOUNT_INTERACTIONS=0 -DDEBUG=0 $(MAKE_OPTS)
 CHARMC = $(CHARM_HOME)/bin/charmc $(OPTS)
 
 OBJS = Paratreet.o Reader.o Writer.o Particle.o BoundingBox.o Decomposition.o Modularization.o TreeSpec.o

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -161,6 +161,10 @@ module paratreet {
     entry DecompArrayMap(CkPointer<Decomposition>, int, int);
   };
 
+  namespace aggregation {
+    initproc void initialize(void);
+  }
+
   extern entry void Reader request<CentroidData>(CProxy_Subtree<CentroidData>, int, int);
   extern entry void Reader flush<CentroidData>(int, int, CProxy_Subtree<CentroidData>);
   extern entry void Reader assignPartitions<CentroidData>(int, int, CProxy_Partition<CentroidData>);

--- a/src/paratreet.ci
+++ b/src/paratreet.ci
@@ -161,6 +161,7 @@ module paratreet {
     entry DecompArrayMap(CkPointer<Decomposition>, int, int);
   };
 
+  include "hypercomm/registration.hpp";
   namespace aggregation {
     initproc void initialize(void);
   }


### PR DESCRIPTION
With TRAM having so many problems with templated entry methods that are beyond fixing manually, this PR integrates Justin's Hypercomm aggregation library instead.