### PR TITLE
Allow Ewald to be compiled without HEXADECAPOLE defined.

### DIFF
--- a/examples/Ewald.C
+++ b/examples/Ewald.C
@@ -126,7 +126,7 @@ void EwaldData::EwaldInit(const struct CentroidData root, const CkCallback& cb)
 				QEVAL(momcRoot, gam, hx, hy, hz,
 				      ax, ay, az, mfacc);
 #else
-				QEVAL(root.moments, gam, hx, hy, hz,
+				QEVAL(multipoles, gam, hx, hy, hz,
 				      ax, ay, az, mfacc);
 #endif
 				gam[0] = exp(-k4*h2)/(M_PI*h2*L);
@@ -146,7 +146,7 @@ void EwaldData::EwaldInit(const struct CentroidData root, const CkCallback& cb)
 				QEVAL(momcRoot, gam,hx,hy,hz,
 				      ax,ay,az,mfacs);
 #else
-				QEVAL(root.moments, gam,hx,hy,hz,
+				QEVAL(multipoles, gam,hx,hy,hz,
 				      ax,ay,az,mfacs);
 #endif
                                 EWT hentry;

--- a/examples/Ewald.h
+++ b/examples/Ewald.h
@@ -6,15 +6,15 @@ PARATREET_REGISTER_PER_LEAF_FN(LeafEwaldFn, CentroidData, (
 #ifdef HEXADECAPOLE
         MOMC mom = ewaldProxy.ckLocalBranch()->momcRoot;
 	MultipoleMoments &momQuad = ewaldProxy.ckLocalBranch()->multipoles;
-        auto ewt = ewaldProxy.ckLocalBranch()->ewt;
 	double xx,xxx,xxy,xxz,yy,yyy,yyz,xyy,zz,zzz,xzz,yzz,xy,xyz,xz,yz;
 	double Q4mirx,Q4miry,Q4mirz,Q4mir,Q4x,Q4y,Q4z;
 	double Q4xx,Q4xy,Q4xz,Q4yy,Q4yz,Q4zz,Q4,Q3x,Q3y,Q3z;
 	double Q3mirx,Q3miry,Q3mirz,Q3mir;
 	const double onethird = 1.0/3.0;
 #else
-	MultipoleMoments mom = root->moments;
+	MultipoleMoments mom = ewaldProxy.ckLocalBranch()->multipoles;
 #endif
+        auto ewt = ewaldProxy.ckLocalBranch()->ewt;
 	double Q2;
 	double L,fEwCut2,fInner2,alpha,alpha2,alphan,k1,ka;
 	double fPot,ax,ay,az;

--- a/examples/EwaldData.h
+++ b/examples/EwaldData.h
@@ -12,7 +12,9 @@ typedef struct ewaldTable
 class EwaldData : public CBase_EwaldData {
 public:
     std::vector<EWT> ewt;
+#ifdef HEXADECAPOLE
     MOMC momcRoot;  /* hold complete multipole moments */
+#endif
     MultipoleMoments multipoles; /* multipole of root cell */
     EwaldData() { }
     void EwaldInit(const struct CentroidData, const CkCallback& cb);


### PR DESCRIPTION
This compiles, but I have not checked for accuracy.