### PR TITLE
Fix linking of xdr library

### DIFF
--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -8,7 +8,7 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 LD_LIBS:=$(LD_LIBS) -L$(PARATREET_PATH) -lparatreet
 
 # XDR library for Tipsy file I/O
-XDR_PATH=$(BASE_PATH)/utility/xdr/xdr
+XDR_PATH=$(BASE_PATH)/utility/xdr
 ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
 	INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
 	LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -7,6 +7,13 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 
 LD_LIBS:=$(LD_LIBS) -L$(PARATREET_PATH) -lparatreet
 
+# XDR library for Tipsy file I/O
+XDR_PATH=$(BASE_PATH)/utility/xdr/xdr
+ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
+	INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
+	LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr
+endif
+
 # TIRPC is required on Summit
 TIRPC_PATH?=/usr/include/tirpc
 ifneq (,$(wildcard $(TIRPC_PATH)))


### PR DESCRIPTION
There need to be two changes to make paratreet work now:

1. move up the commit of the "utility" directory to the most recent commit (to get the xdr folder)
2. Properly link the xdr library (lxdr after lparatreet) when building example programs

This will allow paratreet to be used on machines without librpc (like delta).