### PR TITLE
Make a virtual destructor for MainBase and fix xdr linking

### DIFF
--- a/.github/workflows/non_smp.yml
+++ b/.github/workflows/non_smp.yml
@@ -22,6 +22,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    # Install system dependencies required for XDR (libtirpc)
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libtirpc-dev
+
     # Build Charm++
     - name: build-charm++
       run: |

--- a/.github/workflows/non_smp.yml
+++ b/.github/workflows/non_smp.yml
@@ -38,6 +38,8 @@ jobs:
         cd utility/structures
         ./configure
         make
+        cd ../xdr
+        make
 
     # Build and test ParaTreeT
     - name: build-paratreet

--- a/.github/workflows/smp.yml
+++ b/.github/workflows/smp.yml
@@ -22,6 +22,12 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    # Install system dependencies required for XDR (libtirpc)
+    - name: Install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libtirpc-dev
+
     # Build Charm++
     - name: build-charm++
       run: |

--- a/.github/workflows/smp.yml
+++ b/.github/workflows/smp.yml
@@ -38,6 +38,8 @@ jobs:
         cd utility/structures
         ./configure
         make
+        cd ../xdr
+        make
 
     # Build and test ParaTreeT
     - name: build-paratreet

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -8,7 +8,7 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 LD_LIBS:=$(LD_LIBS) -L$(PARATREET_PATH) -lparatreet
 
 # XDR library for Tipsy file I/O
-XDR_PATH=$(BASE_PATH)/utility/xdr/xdr
+XDR_PATH=$(BASE_PATH)/utility/xdr
 ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
 	INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
 	LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -8,10 +8,26 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 LD_LIBS:=$(LD_LIBS) -L$(PARATREET_PATH) -lparatreet
 
 # XDR library for Tipsy file I/O
-XDR_PATH=$(BASE_PATH)/utility/xdr
-ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
-	INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
-	LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr
+# First check for system RPC XDR library, then fall back to utility/xdr
+HAS_SYSTEM_XDR := $(shell echo '\#include <rpc/xdr.h>' | $(CC) -E - >/dev/null 2>&1 && echo yes)
+ifeq ($(HAS_SYSTEM_XDR),yes)
+	# Use system RPC XDR library
+	# Try different library names depending on the system
+	HAS_LIBRPC := $(shell $(CC) -lrpc -xc /dev/null -o /dev/null >/dev/null 2>&1 && echo yes)
+	HAS_LIBTIRPC := $(shell $(CC) -ltirpc -xc /dev/null -o /dev/null >/dev/null 2>&1 && echo yes)
+	ifeq ($(HAS_LIBRPC),yes)
+		LD_LIBS:=$(LD_LIBS) -lrpc
+	else ifeq ($(HAS_LIBTIRPC),yes)
+		LD_LIBS:=$(LD_LIBS) -ltirpc
+	endif
+	# If neither library is needed, XDR functions are in libc (older glibc)
+else
+	# Fall back to utility/xdr library
+	XDR_PATH=$(BASE_PATH)/utility/xdr
+	ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
+		INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
+		LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr
+	endif
 endif
 
 # TIRPC is required on Summit

--- a/src/Makefile.common
+++ b/src/Makefile.common
@@ -7,6 +7,13 @@ CHARM_HOME ?= $(HOME)/charm-paratreet
 
 LD_LIBS:=$(LD_LIBS) -L$(PARATREET_PATH) -lparatreet
 
+# XDR library for Tipsy file I/O
+XDR_PATH=$(BASE_PATH)/utility/xdr/xdr
+ifneq (,$(wildcard $(XDR_PATH)/libxdr.a))
+	INCLUDES:=$(INCLUDES) -I$(BASE_PATH)/utility/xdr
+	LD_LIBS:=$(LD_LIBS) -L$(XDR_PATH) -lxdr
+endif
+
 # TIRPC is required on Summit
 TIRPC_PATH?=/usr/include/tirpc
 ifneq (,$(wildcard $(TIRPC_PATH)))

--- a/src/Paratreet.h
+++ b/src/Paratreet.h
@@ -92,6 +92,8 @@ namespace paratreet {
         virtual void initializeDriver(const CkCallback&) = 0;
 
         virtual void setDefaults(void) {}
+
+        virtual ~MainBase() = default;
     };
 
     // NOTE because this is called Main, the user's instantiation cannot be
@@ -110,7 +112,7 @@ namespace paratreet {
 
         // pass the configuration without a deleter by default
         Main(void)
-        : MainBase(std::shared_ptr<Configuration>(&conf, [](void*){})) {}
+        : MainBase(std::shared_ptr<Configuration>(&conf, [](Configuration* ptr){ /* no-op deleter for stack object */ })) {}
 
         virtual void initializeDriver(const CkCallback& cb) override {
             this->driver = initialize<T>(cb);


### PR DESCRIPTION
I was getting this error at the end of paratreet runs

`Trace/BPT trap: 5`

This can if you don't clearly define a virtual destructor for a virtual class, and it happens every time in paratreet because in the Main class, you can create MainBase without a deleter by default.

The paratreet program will run completely correctly until this happens. This PR will fix this completely.